### PR TITLE
Replaced constants to be removed in HA Core 2025.1

### DIFF
--- a/custom_components/rs_wfirex4/remote.py
+++ b/custom_components/rs_wfirex4/remote.py
@@ -18,8 +18,10 @@ from homeassistant.components.remote import (
     ATTR_DELAY_SECS,
     ATTR_NUM_REPEATS,
     DEFAULT_DELAY_SECS,
-    SUPPORT_LEARN_COMMAND,
+    SERVICE_LEARN_COMMAND,
+    SERVICE_SEND_COMMAND,
     RemoteEntity,
+    RemoteEntityFeature,
 )
 
 from homeassistant.helpers.storage import Store
@@ -99,6 +101,10 @@ class Wfirex4Remote(RemoteEntity):
         self._state = True
         self._codeRegx = re.compile(r'^[0-9a-f]{32,}$')
 
+        self._attr_supported_features = (
+            RemoteEntityFeature.LEARN_COMMAND
+        )
+
     @property
     def should_poll(self):
         """No polling needed for a RS-WFIREX4 remote."""
@@ -139,10 +145,6 @@ class Wfirex4Remote(RemoteEntity):
         return attr
 
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_LEARN_COMMAND
-
     def turn_on(self, **kwargs):
         """Turn the remote on."""
         self._state = True

--- a/custom_components/rs_wfirex4/sensor.py
+++ b/custom_components/rs_wfirex4/sensor.py
@@ -9,12 +9,20 @@ import asyncio
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import (
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_POWER_FACTOR,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
 )
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_HOST, CONF_NAME, CONF_SCAN_INTERVAL, PERCENTAGE, TEMP_CELSIUS, LIGHT_LUX
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    CONF_HOST,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+    PERCENTAGE,
+    LIGHT_LUX,
+    UnitOfTemperature,
+)
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_call_later
@@ -30,10 +38,10 @@ CONF_ATTRIBUTION = ""
 
 # Sensor type list
 SENSOR_TYPES = {
-    "temperature": ("Temperature", TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE),
-    "humidity": ("Humidity", PERCENTAGE, DEVICE_CLASS_HUMIDITY),
-    "light": ("Light", LIGHT_LUX, DEVICE_CLASS_ILLUMINANCE),
-    "reliability": ("Reliability", PERCENTAGE, DEVICE_CLASS_POWER_FACTOR),
+    "temperature": ("Temperature", UnitOfTemperature.CELSIUS, SensorDeviceClass.TEMPERATURE),
+    "humidity": ("Humidity", PERCENTAGE, SensorDeviceClass.HUMIDITY),
+    "light": ("Light", LIGHT_LUX, SensorDeviceClass.ILLUMINANCE),
+    "reliability": ("Reliability", PERCENTAGE, SensorDeviceClass.POWER_FACTOR),
 }
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
There was a recent change in the hass API that included some deprecated constants in remote.py and sensor.py. These deprecated constants have been rewritten as they are expected to be removed in HA Core 2025.1 and will no longer work.

After the changes were made, I have been running the system from yesterday to today and have not experienced any problems.